### PR TITLE
feat: implement project-specific persistence directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .claude/
 .agent-work/
 .nvim-server
+
+# Claude Code hooks
+.nvim-claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Per-file baseline management for accurate diff tracking
 - Hunk indicators for deletion-only hunks (shows `[Hunk X/Y]` on red deletion lines)
+- Project-specific persistence directory `.nvim-claude/` for state isolation
 
 ### Fixed
 - Fixed phantom diff hunks at end of files caused by newline inconsistencies
@@ -24,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `<leader>cb` behavior changed to match `:ClaudeBg` command (opens interactive UI)
 - Removed all debug logging for cleaner output
+- Moved all state files from global locations to project-specific `.nvim-claude/` directory
+- Server address now stored in `.nvim-claude/nvim-server` instead of `.nvim-server`
+- Inline diff state now stored in `.nvim-claude/inline-diff-state.json` instead of global data directory
 
 ## [0.0.2] - 2025-01-12
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ### Testing Changes
 ```bash
 # Test plugin in Neovim (from parent directory)
-nvim --listen /tmp/nvim-server.pipe  # Required for hooks to work
+nvim  # Plugin automatically handles server setup
 :source lua/nvim-claude/init.lua     # Reload plugin
 :ClaudeDebugInlineDiff               # Debug inline diff state
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Neovim plugin for seamless integration with Claude AI, featuring tmux-based ch
 ## Requirements
 
 ### Required
-- Neovim >= 0.9.0 (must be started with `--listen` or have `v:servername` set for hooks)
+- Neovim >= 0.9.0
 - [Claude Code CLI](https://claude.ai/download) - The `claude` command must be in your PATH
 - Tmux (for chat interface and background agents)
 - Git (for diff management and worktrees)
@@ -25,7 +25,8 @@ A Neovim plugin for seamless integration with Claude AI, featuring tmux-based ch
 - [which-key.nvim](https://github.com/folke/which-key.nvim) - For keybinding hints
 
 ### Notes
-- For inline diff hooks to work, Neovim must be started with a server name (e.g., `nvim --listen /tmp/nvim-server.pipe`)
+- The plugin creates a `.nvim-claude/` directory in your project root for storing state
+- Neovim's server address is automatically saved to `.nvim-claude/nvim-server`
 - On macOS, Claude Code CLI can be installed from the Claude desktop app
 - The plugin uses git worktrees for agent isolation, so Git 2.5+ is recommended
 

--- a/hooks.lua
+++ b/hooks.lua
@@ -655,9 +655,9 @@ function M.install_hooks()
       table.insert(entries_to_add, '.claude/')
     end
 
-    -- Check for .nvim-server
-    if not gitignore_content:match '%.nvim%-server' then
-      table.insert(entries_to_add, '.nvim-server')
+    -- Check for .nvim-claude/
+    if not gitignore_content:match '%.nvim%-claude/' then
+      table.insert(entries_to_add, '.nvim-claude/')
     end
 
     -- Add entries if needed

--- a/settings-updater.lua
+++ b/settings-updater.lua
@@ -15,9 +15,19 @@ function M.update_claude_settings()
     return
   end
 
+  -- Ensure .nvim-claude directory exists
+  local nvim_claude_dir = project_root .. '/.nvim-claude'
+  utils.ensure_dir(nvim_claude_dir)
+  
   -- Write server address to project-specific file for proxy script
-  local server_file = project_root .. '/.nvim-server'
+  local server_file = nvim_claude_dir .. '/nvim-server'
   vim.fn.writefile({ server_addr }, server_file)
+  
+  -- Migrate old .nvim-server file if it exists
+  local old_server_file = project_root .. '/.nvim-server'
+  if utils.file_exists(old_server_file) then
+    os.remove(old_server_file)
+  end
 
   -- Use the install_hooks function from hooks module to update settings
   local hooks = require 'nvim-claude.hooks'


### PR DESCRIPTION
- Move all state files to .nvim-claude/ directory in project root
- Migrate nvim-server from .nvim-server to .nvim-claude/nvim-server
- Move inline-diff-state.json to .nvim-claude/inline-diff-state.json
- Add automatic migration for existing state files
- Update gitignore to use .nvim-claude/ instead of individual files
- Fix cross-project state contamination issues